### PR TITLE
Updated docker-compose file not to use external network for intra-svc comms

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     ports:
       - "8000"
     environment:
-      - GITHUB_MANAGER_MICROSERVICES_IP=${GITHUB_MANAGER_MICROSERVICES_IP}
+      - GITHUB_MANAGER_MICROSERVICES_IP=nginx
     command: /usr/local/bin/gunicorn -w 2 -b :8000 app:app
 
   email:


### PR DESCRIPTION
The way the 'web' uSvc is coded, is it is going to reach out to ${GITHUB_MANAGER_MICROSERVICES_IP}/github/prs/get (i.e. it expects to talk back to nginx to be routed back to the 'github' uSvc.
This change removes the use of external IP of the docker host, which saves the unnecessary roundtrip & allows this to run in a non-virtualized docker host (when the GITHUB_MANAGER_MICROSERVICES_IP is localhost)